### PR TITLE
Implement ingestion of financial data

### DIFF
--- a/backend/gaigentic_backend/main.py
+++ b/backend/gaigentic_backend/main.py
@@ -10,7 +10,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from sqlalchemy import text
 
 from .database import engine
-from .routes import api_router, agents
+from .routes import api_router, agents, ingestion
 
 logger = logging.getLogger(__name__)
 
@@ -43,3 +43,4 @@ app = FastAPI(title="Gaigentic Backend", lifespan=lifespan)
 app.add_middleware(RequestIDMiddleware)
 app.include_router(api_router)
 app.include_router(agents.router, prefix="/api/v1/agents")
+app.include_router(ingestion.router, prefix="/api/v1/ingest")

--- a/backend/gaigentic_backend/migrations/versions/ad94e75a3fbe_add_transactions_table.py
+++ b/backend/gaigentic_backend/migrations/versions/ad94e75a3fbe_add_transactions_table.py
@@ -1,0 +1,30 @@
+"""add transactions table"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "ad94e75a3fbe"
+down_revision = "547a6a017bd2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "transactions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("date", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("amount", sa.Float(), nullable=False),
+        sa.Column("type", sa.String(length=255), nullable=True),
+        sa.Column("description", sa.String(length=1024), nullable=True),
+        sa.Column("source_file_name", sa.String(length=255), nullable=False),
+        sa.Column("uploaded_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenant.id"], ondelete="CASCADE"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("transactions")

--- a/backend/gaigentic_backend/models/__init__.py
+++ b/backend/gaigentic_backend/models/__init__.py
@@ -2,4 +2,5 @@
 from .tenant import Tenant
 from .agent import Agent
 
-__all__ = ["Tenant", "Agent"]
+from .transaction import Transaction
+__all__ = ["Tenant", "Agent", "Transaction"]

--- a/backend/gaigentic_backend/models/transaction.py
+++ b/backend/gaigentic_backend/models/transaction.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, Float, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from ..database import Base
+
+
+class Transaction(Base):
+    """Financial transaction record."""
+
+    __tablename__ = "transactions"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenant.id", ondelete="CASCADE"), nullable=False)
+    date = Column(DateTime(timezone=True), nullable=False)
+    amount = Column(Float, nullable=False)
+    type = Column(String(255), nullable=True)
+    description = Column(String(1024), nullable=True)
+    source_file_name = Column(String(255), nullable=False)
+    uploaded_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/gaigentic_backend/routes/ingestion.py
+++ b/backend/gaigentic_backend/routes/ingestion.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, File, UploadFile, HTTPException, status
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database import async_session
+from ..models.transaction import Transaction
+from ..services.file_parser import parse_file
+from ..services.tenant_context import get_current_tenant_id
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+async def ingest_transactions(
+    file: UploadFile = File(...),
+    session: AsyncSession = Depends(async_session),
+    tenant_id: UUID = Depends(get_current_tenant_id),
+) -> dict:
+    """Upload a CSV or XLSX file and store transactions."""
+
+    records = parse_file(file)
+    transactions: List[Transaction] = []
+    for rec in records:
+        transactions.append(
+            Transaction(
+                tenant_id=tenant_id,
+                date=rec["date"],
+                amount=rec["amount"],
+                description=rec.get("description"),
+                type=rec.get("type"),
+                source_file_name=file.filename or "",
+            )
+        )
+
+    session.add_all(transactions)
+    try:
+        await session.commit()
+    except SQLAlchemyError as exc:  # pragma: no cover - runtime path
+        logger.exception("Failed to ingest transactions: %s", exc)
+        await session.rollback()
+        raise HTTPException(status_code=500, detail="Could not store transactions")
+
+    row_count = len(transactions)
+    logger.info(
+        "Ingested %s transactions from %s for tenant %s", row_count, file.filename, tenant_id
+    )
+    return {"rows_imported": row_count}

--- a/backend/gaigentic_backend/schemas/transaction.py
+++ b/backend/gaigentic_backend/schemas/transaction.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class TransactionIngested(BaseModel):
+    date: datetime
+    amount: float
+    description: str | None = None
+    type: str | None = None
+
+
+class TransactionRecord(BaseModel):
+    id: UUID
+    tenant_id: UUID
+    date: datetime
+    amount: float
+    description: str | None = None
+    type: str | None = None
+    source_file_name: str
+    uploaded_at: datetime
+
+    model_config = {
+        "json_encoders": {datetime: lambda v: v.isoformat()},
+    }

--- a/backend/gaigentic_backend/services/file_parser.py
+++ b/backend/gaigentic_backend/services/file_parser.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+import logging
+from typing import List, Dict
+import pandas as pd
+from fastapi import UploadFile, HTTPException, status
+
+logger = logging.getLogger(__name__)
+
+MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
+
+
+def _validate_columns(df: pd.DataFrame) -> None:
+    required = {"date", "amount", "description"}
+    missing = required - set(df.columns)
+    if missing:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Missing required columns: {', '.join(sorted(missing))}",
+        )
+
+
+def parse_file(file: UploadFile) -> List[Dict]:
+    """Parse an uploaded CSV or XLSX file into transaction records."""
+
+    file.file.seek(0, os.SEEK_END)
+    size = file.file.tell()
+    file.file.seek(0)
+    if size > MAX_FILE_SIZE:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="File too large")
+
+    filename = (file.filename or "").lower()
+    try:
+        if filename.endswith(".csv"):
+            df = pd.read_csv(file.file)
+        elif filename.endswith(".xlsx"):
+            df = pd.read_excel(file.file)
+        else:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported file type")
+    except Exception as exc:  # pragma: no cover - runtime parsing errors
+        logger.exception("Failed to parse uploaded file: %s", exc)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid file format") from exc
+
+    _validate_columns(df)
+
+    records: List[Dict] = []
+    for _, row in df.iterrows():
+        try:
+            date = pd.to_datetime(row["date"]).to_pydatetime()
+        except Exception:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid date value")
+        try:
+            amount = float(row["amount"])
+        except Exception:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid amount value")
+        record = {
+            "date": date,
+            "amount": amount,
+            "description": None if pd.isna(row.get("description")) else str(row.get("description")),
+            "type": None if pd.isna(row.get("type")) else str(row.get("type")),
+        }
+        records.append(record)
+
+    return records

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,5 @@ sqlalchemy>=2.0
 psycopg2-binary
 pydantic-settings
 alembic
+pandas
+openpyxl

--- a/tests/fixtures/sample_transactions.csv
+++ b/tests/fixtures/sample_transactions.csv
@@ -1,0 +1,3 @@
+date,amount,description,type
+2023-05-01,100,Payment,"credit"
+2023-05-02,-50,Groceries,"debit"


### PR DESCRIPTION
## Summary
- add transaction model and migration
- create ingestion route for uploading transactions
- parse CSV/XLSX files with pandas
- expose ingestion router in the app
- add sample CSV fixture instead of Excel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685252a9debc832c91e7427276eb84be