### PR TITLE
Implement execution logging and analytics

### DIFF
--- a/backend/gaigentic_backend/main.py
+++ b/backend/gaigentic_backend/main.py
@@ -10,7 +10,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from sqlalchemy import text
 
 from .database import engine
-from .routes import api_router, agents, ingestion, chat
+from .routes import api_router, agents, ingestion, chat, analytics
 
 logger = logging.getLogger(__name__)
 
@@ -45,3 +45,4 @@ app.include_router(api_router)
 app.include_router(agents.router, prefix="/api/v1/agents")
 app.include_router(ingestion.router, prefix="/api/v1/ingest")
 app.include_router(chat.router)
+app.include_router(analytics.router, prefix="/api/v1")

--- a/backend/gaigentic_backend/migrations/versions/1e8f2c9188f3_add_execution_log_table.py
+++ b/backend/gaigentic_backend/migrations/versions/1e8f2c9188f3_add_execution_log_table.py
@@ -1,0 +1,33 @@
+"""add execution log table"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "1e8f2c9188f3"
+down_revision = "0c2e03952e35"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "execution_log",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("workflow_snapshot", postgresql.JSONB(), nullable=False),
+        sa.Column("input_context", postgresql.JSONB(), nullable=False),
+        sa.Column("output_result", postgresql.JSONB(), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("duration_ms", sa.Integer(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenant.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["agent_id"], ["agent.id"], ondelete="CASCADE"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("execution_log")

--- a/backend/gaigentic_backend/models/__init__.py
+++ b/backend/gaigentic_backend/models/__init__.py
@@ -4,5 +4,12 @@ from .agent import Agent
 
 from .transaction import Transaction
 from .chat_session import ChatSession
+from .execution_log import ExecutionLog
 
-__all__ = ["Tenant", "Agent", "Transaction", "ChatSession"]
+__all__ = [
+    "Tenant",
+    "Agent",
+    "Transaction",
+    "ChatSession",
+    "ExecutionLog",
+]

--- a/backend/gaigentic_backend/models/execution_log.py
+++ b/backend/gaigentic_backend/models/execution_log.py
@@ -1,0 +1,26 @@
+"""Workflow execution logging model."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+from ..database import Base
+
+
+class ExecutionLog(Base):
+    """Record of a workflow execution."""
+
+    __tablename__ = "execution_log"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenant.id", ondelete="CASCADE"), nullable=False)
+    agent_id = Column(UUID(as_uuid=True), ForeignKey("agent.id", ondelete="CASCADE"), nullable=False)
+    workflow_snapshot = Column(JSONB, nullable=False)
+    input_context = Column(JSONB, nullable=False)
+    output_result = Column(JSONB, nullable=True)
+    status = Column(String(32), nullable=False)
+    duration_ms = Column(Integer, nullable=False)
+    started_at = Column(DateTime(timezone=True), nullable=False)
+    finished_at = Column(DateTime(timezone=True), nullable=False)

--- a/backend/gaigentic_backend/routes/agents.py
+++ b/backend/gaigentic_backend/routes/agents.py
@@ -17,7 +17,7 @@ from ..services.tool_executor import execute_tool
 from ..services.flow_validator import validate_workflow
 from ..services.workflow_translator import translate_to_superagent
 from ..services.superagent_client import get_superagent_client
-from ..services.workflow_executor import run_workflow
+from ..services.logging_executor import run_logged_workflow
 from ..schemas.chat import WorkflowDraft
 import httpx
 
@@ -142,4 +142,4 @@ async def execute_workflow(
     if agent is None or agent.tenant_id != tenant_id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
 
-    return await run_workflow(agent_id, input_context)
+    return await run_logged_workflow(agent_id, input_context)

--- a/backend/gaigentic_backend/routes/analytics.py
+++ b/backend/gaigentic_backend/routes/analytics.py
@@ -1,0 +1,74 @@
+"""Analytics routes for execution monitoring."""
+from __future__ import annotations
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database import async_session
+from ..models.agent import Agent
+from ..models.transaction import Transaction
+from ..models.execution_log import ExecutionLog
+from ..services.tenant_context import get_current_tenant_id
+
+router = APIRouter()
+
+
+@router.get("/agents/{agent_id}/runs")
+async def get_agent_runs(
+    agent_id: UUID,
+    session: AsyncSession = Depends(async_session),
+    tenant_id: UUID = Depends(get_current_tenant_id),
+) -> List[dict]:
+    """Return recent execution logs for an agent."""
+
+    query = (
+        select(ExecutionLog.started_at, ExecutionLog.status, ExecutionLog.duration_ms)
+        .where(
+            ExecutionLog.agent_id == agent_id,
+            ExecutionLog.tenant_id == tenant_id,
+        )
+        .order_by(ExecutionLog.started_at.desc())
+        .limit(20)
+    )
+    result = await session.execute(query)
+    return [dict(r) for r in result.all()]
+
+
+@router.get("/tenants/{tenant_id}/stats")
+async def tenant_stats(
+    tenant_id: UUID,
+    session: AsyncSession = Depends(async_session),
+    current: UUID = Depends(get_current_tenant_id),
+) -> dict:
+    """Return aggregate statistics for a tenant."""
+
+    if tenant_id != current:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+    agent_count = await session.scalar(
+        select(func.count(Agent.id)).where(Agent.tenant_id == tenant_id)
+    )
+    file_count = await session.scalar(
+        select(func.count(func.distinct(Transaction.source_file_name))).where(
+            Transaction.tenant_id == tenant_id
+        )
+    )
+    exec_count = await session.scalar(
+        select(func.count(ExecutionLog.id)).where(ExecutionLog.tenant_id == tenant_id)
+    )
+    avg_duration = await session.scalar(
+        select(func.coalesce(func.avg(ExecutionLog.duration_ms), 0)).where(
+            ExecutionLog.tenant_id == tenant_id
+        )
+    )
+    return {
+        "agents": agent_count or 0,
+        "ingested_files": file_count or 0,
+        "executions": exec_count or 0,
+        "avg_duration_ms": int(avg_duration or 0),
+    }
+

--- a/backend/gaigentic_backend/services/logging_executor.py
+++ b/backend/gaigentic_backend/services/logging_executor.py
@@ -1,0 +1,71 @@
+"""Workflow execution with runtime logging."""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database import SessionLocal
+from ..models.execution_log import ExecutionLog
+from .tenant_context import get_current_tenant_id
+from .workflow_executor import _load_agent, run_workflow
+
+logger = logging.getLogger(__name__)
+
+
+async def run_logged_workflow(agent_id: UUID, input_context: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute a workflow and persist an execution log."""
+
+    tenant_id = await get_current_tenant_id()
+    started = datetime.now(tz=timezone.utc)
+    status = "success"
+    output: Dict[str, Any] | None = None
+    workflow_snapshot: Dict[str, Any] | None = None
+
+    try:
+        agent = await _load_agent(agent_id, tenant_id)
+        workflow_snapshot = (agent.config or {}).get("workflow") or {}
+        output = await run_workflow(agent_id, input_context)
+        status = "success"
+        return output
+    except HTTPException as exc:
+        status = "failure" if 400 <= exc.status_code < 500 else "error"
+        raise
+    except Exception:
+        status = "error"
+        raise
+    finally:
+        finished = datetime.now(tz=timezone.utc)
+        duration_ms = int((finished - started).total_seconds() * 1000)
+        log_output: Any = output
+        try:
+            serialized = json.dumps(output or {}).encode()
+            if len(serialized) > 100_000:
+                log_output = {"truncated": True}
+        except Exception:
+            log_output = {"error": "unserializable"}
+
+        log_entry = ExecutionLog(
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            workflow_snapshot=workflow_snapshot or {},
+            input_context=input_context,
+            output_result=log_output,
+            status=status,
+            duration_ms=duration_ms,
+            started_at=started,
+            finished_at=finished,
+        )
+        async with SessionLocal() as session:  # type: AsyncSession
+            session.add(log_entry)
+            try:
+                await session.commit()
+            except Exception:  # pragma: no cover - runtime commit failure
+                logger.exception("Failed to store execution log")
+                await session.rollback()
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
 import Chat from './pages/Chat'
 import Builder from './pages/Builder'
+import Monitor from './pages/Monitor'
 
 export default function App() {
   return (
@@ -8,10 +9,12 @@ export default function App() {
       <nav className="p-2 bg-gray-100 flex space-x-4">
         <Link to="/" className="text-blue-600">Chat</Link>
         <Link to="/Builder" className="text-blue-600">Builder</Link>
+        <Link to="/Monitor" className="text-blue-600">Monitor</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Chat />} />
         <Route path="/Builder" element={<Builder />} />
+        <Route path="/Monitor" element={<Monitor />} />
       </Routes>
     </BrowserRouter>
   )

--- a/frontend/src/pages/Monitor.tsx
+++ b/frontend/src/pages/Monitor.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+
+interface RunLog {
+  started_at: string
+  status: string
+  duration_ms: number
+}
+
+interface TenantStats {
+  agents: number
+  ingested_files: number
+  executions: number
+  avg_duration_ms: number
+}
+
+export default function Monitor() {
+  const location = useLocation()
+  const params = new URLSearchParams(location.search)
+  const agentId = params.get('agent_id') || ''
+
+  const [runs, setRuns] = useState<RunLog[]>([])
+  const [stats, setStats] = useState<TenantStats | null>(null)
+
+  useEffect(() => {
+    if (agentId) {
+      fetch(`/api/v1/agents/${agentId}/runs`)
+        .then((r) => r.json())
+        .then(setRuns)
+        .catch(() => {})
+    }
+  }, [agentId])
+
+  useEffect(() => {
+    const tenantId = '00000000-0000-0000-0000-000000000001'
+    fetch(`/api/v1/tenants/${tenantId}/stats`)
+      .then((r) => r.json())
+      .then(setStats)
+      .catch(() => {})
+  }, [])
+
+  const successPct = runs.length
+    ? Math.round((runs.filter((r) => r.status === 'success').length / runs.length) * 100)
+    : 0
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-lg font-bold">Execution Metrics</h2>
+      {stats && (
+        <div className="space-x-4">
+          <span>Total Runs: {stats.executions}</span>
+          <span>Avg Duration: {stats.avg_duration_ms}ms</span>
+          <span>Success %: {successPct}%</span>
+        </div>
+      )}
+      <h2 className="text-lg font-bold mt-4">Run History</h2>
+      {runs.length ? (
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="px-2 py-1">Started</th>
+              <th className="px-2 py-1">Status</th>
+              <th className="px-2 py-1">Duration (ms)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {runs.map((r, idx) => (
+              <tr key={idx} className="border-t">
+                <td className="px-2 py-1">{new Date(r.started_at).toLocaleString()}</td>
+                <td className="px-2 py-1">{r.status}</td>
+                <td className="px-2 py-1">{r.duration_ms}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <div>No runs found.</div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- track workflow runs in new `execution_log` table
- wrap executor with logging service
- expose analytics endpoints for run history and tenant stats
- add monitoring page to frontend
- update backend app router to include analytics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852608e2a3c832c9594490c998fdf16