### PR TITLE
Add template marketplace

### DIFF
--- a/backend/gaigentic_backend/main.py
+++ b/backend/gaigentic_backend/main.py
@@ -10,7 +10,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from sqlalchemy import text, select
 
 from .database import engine, SessionLocal
-from .routes import api_router, agents, ingestion, chat, analytics, auth
+from .routes import api_router, agents, ingestion, chat, analytics, auth, templates
 from .models.user import User, RoleEnum
 from .models.tenant import Tenant
 from .config import settings
@@ -68,3 +68,4 @@ app.include_router(agents.router, prefix="/api/v1/agents")
 app.include_router(ingestion.router, prefix="/api/v1/ingest")
 app.include_router(chat.router)
 app.include_router(analytics.router, prefix="/api/v1")
+app.include_router(templates.router)

--- a/backend/gaigentic_backend/migrations/versions/3b80048a93c7_add_templates_table.py
+++ b/backend/gaigentic_backend/migrations/versions/3b80048a93c7_add_templates_table.py
@@ -1,0 +1,29 @@
+"""add templates table"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "3b80048a93c7"
+down_revision = "2c7e68cd38d5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "template",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.String(length=1024), nullable=False),
+        sa.Column("workflow_draft", postgresql.JSONB(), nullable=False),
+        sa.Column("system_prompt", sa.Text(), nullable=True),
+        sa.Column("created_by", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("name"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("template")

--- a/backend/gaigentic_backend/models/__init__.py
+++ b/backend/gaigentic_backend/models/__init__.py
@@ -6,6 +6,7 @@ from .transaction import Transaction
 from .chat_session import ChatSession
 from .execution_log import ExecutionLog
 from .user import User
+from .template import Template
 
 __all__ = [
     "Tenant",
@@ -14,4 +15,5 @@ __all__ = [
     "ChatSession",
     "ExecutionLog",
     "User",
+    "Template",
 ]

--- a/backend/gaigentic_backend/models/template.py
+++ b/backend/gaigentic_backend/models/template.py
@@ -1,0 +1,23 @@
+"""Template model for marketplace."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+from ..database import Base
+
+
+class Template(Base):
+    """Prebuilt workflow template."""
+
+    __tablename__ = "template"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    name = Column(String(255), unique=True, nullable=False)
+    description = Column(String(1024), nullable=False)
+    workflow_draft = Column(JSONB, nullable=False)
+    system_prompt = Column(Text, nullable=True)
+    created_by = Column(String(255), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/gaigentic_backend/routes/templates.py
+++ b/backend/gaigentic_backend/routes/templates.py
@@ -1,0 +1,126 @@
+"""Template marketplace routes."""
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database import async_session
+from ..models.template import Template
+from ..models.agent import Agent
+from ..schemas.template import TemplateCreate, TemplateOut
+from ..schemas.chat import WorkflowDraft
+from ..services.flow_validator import validate_workflow
+from ..dependencies.auth import get_current_tenant_id, require_role
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/templates")
+
+
+@router.get("/", response_model=list[TemplateOut])
+async def list_templates(
+    session: AsyncSession = Depends(async_session),
+    _user=Depends(require_role({"admin", "user", "readonly"})),
+) -> list[TemplateOut]:
+    """Return all templates."""
+
+    result = await session.execute(select(Template))
+    templates = result.scalars().all()
+    return [TemplateOut.model_validate(t) for t in templates]
+
+
+@router.get("/{template_id}", response_model=TemplateOut)
+async def get_template(
+    template_id: UUID,
+    session: AsyncSession = Depends(async_session),
+    _user=Depends(require_role({"admin", "user", "readonly"})),
+) -> TemplateOut:
+    """Fetch a single template."""
+
+    template = await session.get(Template, template_id)
+    if template is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return TemplateOut.model_validate(template)
+
+
+@router.post("/", response_model=TemplateOut, status_code=status.HTTP_201_CREATED)
+async def create_template(
+    payload: TemplateCreate,
+    session: AsyncSession = Depends(async_session),
+    user=Depends(require_role({"admin"})),
+) -> TemplateOut:
+    """Create a new template (admins only)."""
+
+    exists = await session.scalar(select(Template.id).where(Template.name == payload.name))
+    if exists:
+        raise HTTPException(status_code=400, detail="Template name already exists")
+
+    try:
+        validate_workflow(payload.workflow_draft)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid workflow") from exc
+
+    prompt = payload.system_prompt or None
+    if prompt and len(prompt) > 10 * 1024:
+        prompt = prompt[: 10 * 1024]
+
+    template = Template(
+        name=payload.name,
+        description=payload.description,
+        workflow_draft=payload.workflow_draft.model_dump(),
+        system_prompt=prompt,
+        created_by=user.email,
+    )
+    session.add(template)
+    try:
+        await session.commit()
+        await session.refresh(template)
+    except SQLAlchemyError as exc:
+        logger.exception("Failed to create template: %s", exc)
+        await session.rollback()
+        raise HTTPException(status_code=500, detail="Could not create template")
+
+    return TemplateOut.model_validate(template)
+
+
+@router.post("/{template_id}/clone", status_code=status.HTTP_201_CREATED)
+async def clone_template(
+    template_id: UUID,
+    session: AsyncSession = Depends(async_session),
+    tenant_id: UUID = Depends(get_current_tenant_id),
+    _user=Depends(require_role({"admin", "user"})),
+) -> dict:
+    """Clone a template into a new agent for the tenant."""
+
+    template = await session.get(Template, template_id)
+    if template is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+    draft_dict = template.workflow_draft
+    try:
+        draft = WorkflowDraft.model_validate(draft_dict)
+        validate_workflow(draft)
+    except ValueError as exc:
+        logger.error("Invalid template workflow: %s", exc)
+        raise HTTPException(status_code=400, detail="Invalid template") from exc
+
+    agent = Agent(
+        tenant_id=tenant_id,
+        name=template.name,
+        config={"workflow": draft_dict, "system_prompt": template.system_prompt},
+    )
+    session.add(agent)
+    try:
+        await session.commit()
+        await session.refresh(agent)
+    except SQLAlchemyError as exc:
+        logger.exception("Failed to clone template: %s", exc)
+        await session.rollback()
+        raise HTTPException(status_code=500, detail="Could not clone template")
+
+    return {"agent_id": str(agent.id)}

--- a/backend/gaigentic_backend/schemas/template.py
+++ b/backend/gaigentic_backend/schemas/template.py
@@ -1,0 +1,32 @@
+"""Pydantic schemas for Template API."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from .chat import WorkflowDraft
+
+
+class TemplateCreate(BaseModel):
+    """Schema for creating templates."""
+
+    name: str = Field(..., max_length=255)
+    description: str
+    workflow_draft: WorkflowDraft
+    system_prompt: str | None = None
+
+
+class TemplateOut(BaseModel):
+    """Public representation of a template."""
+
+    id: UUID
+    name: str
+    description: str
+    workflow_draft: WorkflowDraft
+    system_prompt: str | None = None
+    created_by: str
+    created_at: datetime
+
+    model_config = {"json_encoders": {datetime: lambda v: v.isoformat()}}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
 import Chat from './pages/Chat'
 import Builder from './pages/Builder'
 import Monitor from './pages/Monitor'
+import Templates from './pages/Templates'
 import Login from './pages/Login'
 import Register from './pages/Register'
 import { getToken, clearToken } from './utils/auth'
@@ -19,6 +20,7 @@ export default function App() {
       <nav className="p-2 bg-gray-100 flex space-x-4">
         <Link to="/" className="text-blue-600">Chat</Link>
         <Link to="/Builder" className="text-blue-600">Builder</Link>
+        <Link to="/Templates" className="text-blue-600">Templates</Link>
         <Link to="/Monitor" className="text-blue-600">Monitor</Link>
         {token ? (
           <button onClick={logout} className="text-blue-600">Logout</button>
@@ -29,6 +31,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Chat />} />
         <Route path="/Builder" element={<Builder />} />
+        <Route path="/Templates" element={<Templates />} />
         <Route path="/Monitor" element={<Monitor />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import ReactFlow, { Background } from 'reactflow'
+import 'reactflow/dist/style.css'
+import { getToken } from '../utils/auth'
+
+interface DraftNode {
+  id: string
+  type: string
+  label: string
+  data: Record<string, unknown>
+  position: { x: number; y: number }
+}
+
+interface DraftEdge {
+  id: string
+  source: string
+  target: string
+}
+
+interface Template {
+  id: string
+  name: string
+  description: string
+  workflow_draft: { nodes: DraftNode[]; edges: DraftEdge[] }
+  system_prompt?: string
+}
+
+export default function Templates() {
+  const [templates, setTemplates] = useState<Template[]>([])
+  const [preview, setPreview] = useState<Template | null>(null)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    fetch('/api/v1/templates', {
+      headers: { Authorization: `Bearer ${getToken()}` },
+    })
+      .then((r) => r.json())
+      .then(setTemplates)
+      .catch(() => {})
+  }, [])
+
+  const cloneTemplate = async (id: string) => {
+    const res = await fetch(`/api/v1/templates/${id}/clone`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${getToken()}` },
+    })
+    if (res.ok) {
+      const data = await res.json()
+      navigate(`/Builder?agent_id=${data.agent_id}`)
+    } else {
+      alert('Clone failed')
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-lg font-bold">Templates</h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {templates.map((t) => (
+          <div key={t.id} className="border p-2 rounded space-y-2">
+            <div className="font-bold">{t.name}</div>
+            <div className="text-sm">{t.description}</div>
+            <div className="space-x-2">
+              <button className="px-2 py-1 bg-blue-500 text-white rounded" onClick={() => setPreview(t)}>
+                View
+              </button>
+              <button className="px-2 py-1 bg-green-500 text-white rounded" onClick={() => cloneTemplate(t.id)}>
+                Clone
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      {preview && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center" onClick={() => setPreview(null)}>
+          <div className="bg-white p-4" onClick={(e) => e.stopPropagation()}>
+            <div className="font-bold mb-2">{preview.name}</div>
+            <div className="w-96 h-64">
+              <ReactFlow nodes={preview.workflow_draft.nodes.map((n) => ({ id: n.id, type: n.type, position: n.position, data: { label: n.label } }))} edges={preview.workflow_draft.edges} fitView>
+                <Background />
+              </ReactFlow>
+            </div>
+            <button className="mt-2 px-2 py-1 bg-green-500 text-white rounded" onClick={() => cloneTemplate(preview.id)}>
+              Clone Template
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/scripts/seed_templates.py
+++ b/scripts/seed_templates.py
@@ -1,0 +1,77 @@
+"""Seed default templates."""
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy import select
+
+from backend.gaigentic_backend.database import SessionLocal
+from backend.gaigentic_backend.models.template import Template
+
+TEMPLATES = [
+    (
+        "Cash Forecasting Agent",
+        "Forecast cash flow based on transaction history",
+        {
+            "nodes": [
+                {"id": "start", "type": "start", "label": "Start", "data": {}, "position": {"x": 0, "y": 0}},
+                {"id": "forecast", "type": "forecast", "label": "Forecast", "data": {}, "position": {"x": 200, "y": 0}},
+            ],
+            "edges": [
+                {"id": "e1", "source": "start", "target": "forecast"},
+            ],
+        },
+        "You are a cash forecasting assistant.",
+    ),
+    (
+        "KYC Verification Flow",
+        "Verify customer identity using provided documents",
+        {
+            "nodes": [
+                {"id": "input", "type": "input", "label": "Receive Docs", "data": {}, "position": {"x": 0, "y": 0}},
+                {"id": "check", "type": "kyc_check", "label": "Verify", "data": {}, "position": {"x": 200, "y": 0}},
+            ],
+            "edges": [
+                {"id": "e2", "source": "input", "target": "check"},
+            ],
+        },
+        "Ensure the documents meet compliance standards.",
+    ),
+    (
+        "Fraud Detection Assistant",
+        "Analyze transactions for fraudulent patterns",
+        {
+            "nodes": [
+                {"id": "src", "type": "source", "label": "Transactions", "data": {}, "position": {"x": 0, "y": 0}},
+                {"id": "detect", "type": "fraud", "label": "Detect", "data": {}, "position": {"x": 200, "y": 0}},
+            ],
+            "edges": [
+                {"id": "e3", "source": "src", "target": "detect"},
+            ],
+        },
+        "Flag suspicious activities.",
+    ),
+]
+
+
+async def main() -> None:
+    async with SessionLocal() as session:
+        for name, desc, draft, prompt in TEMPLATES:
+            result = await session.execute(select(Template.id).where(Template.name == name))
+            exists = result.scalar_one_or_none()
+            if exists:
+                continue
+            session.add(
+                Template(
+                    name=name,
+                    description=desc,
+                    workflow_draft=draft,
+                    system_prompt=prompt,
+                    created_by="seed",
+                )
+            )
+        await session.commit()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- introduce `Template` model with migration
- expose `/api/v1/templates` routes for listing, creation and cloning
- add seeding script for default templates
- create Template page on frontend with preview and clone actions
- link templates page in navigation

## Testing
- `python -m compileall backend`
- `python -m compileall frontend`

------
https://chatgpt.com/codex/tasks/task_e_685269ca38a8832c8ca79adb0e1578ae