### PR TITLE
Add KB ingestion and search

### DIFF
--- a/backend/gaigentic_backend/main.py
+++ b/backend/gaigentic_backend/main.py
@@ -10,7 +10,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from sqlalchemy import text, select
 
 from .database import engine, SessionLocal
-from .routes import api_router, agents, ingestion, chat, analytics, auth, templates
+from .routes import api_router, agents, ingestion, chat, analytics, auth, templates, knowledge
 from .models.user import User, RoleEnum
 from .models.tenant import Tenant
 from .config import settings
@@ -69,3 +69,4 @@ app.include_router(ingestion.router, prefix="/api/v1/ingest")
 app.include_router(chat.router)
 app.include_router(analytics.router, prefix="/api/v1")
 app.include_router(templates.router)
+app.include_router(knowledge.router, prefix="/api/v1")

--- a/backend/gaigentic_backend/migrations/versions/4d2b8fb5041d_add_knowledge_chunk.py
+++ b/backend/gaigentic_backend/migrations/versions/4d2b8fb5041d_add_knowledge_chunk.py
@@ -1,0 +1,32 @@
+"""add knowledge chunk table"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from pgvector.sqlalchemy import Vector
+
+revision = "4d2b8fb5041d"
+down_revision = "3b80048a93c7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "knowledge_chunk",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("source_file", sa.String(length=255), nullable=False),
+        sa.Column("chunk_index", sa.Integer(), nullable=False),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("embedding", Vector(1536), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenant.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["agent_id"], ["agent.id"], ondelete="CASCADE"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("knowledge_chunk")

--- a/backend/gaigentic_backend/models/__init__.py
+++ b/backend/gaigentic_backend/models/__init__.py
@@ -7,6 +7,7 @@ from .chat_session import ChatSession
 from .execution_log import ExecutionLog
 from .user import User
 from .template import Template
+from .knowledge_chunk import KnowledgeChunk
 
 __all__ = [
     "Tenant",
@@ -16,4 +17,5 @@ __all__ = [
     "ExecutionLog",
     "User",
     "Template",
+    "KnowledgeChunk",
 ]

--- a/backend/gaigentic_backend/models/knowledge_chunk.py
+++ b/backend/gaigentic_backend/models/knowledge_chunk.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from pgvector.sqlalchemy import Vector
+
+from ..database import Base
+
+
+class KnowledgeChunk(Base):
+    """Stored text chunk for retrieval."""
+
+    __tablename__ = "knowledge_chunk"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenant.id", ondelete="CASCADE"), nullable=False)
+    agent_id = Column(UUID(as_uuid=True), ForeignKey("agent.id", ondelete="CASCADE"), nullable=False)
+    source_file = Column(String(255), nullable=False)
+    chunk_index = Column(Integer, nullable=False)
+    text = Column(Text, nullable=False)
+    embedding = Column(Vector(1536), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/gaigentic_backend/routes/__init__.py
+++ b/backend/gaigentic_backend/routes/__init__.py
@@ -1,8 +1,9 @@
 """Application routers."""
 from fastapi import APIRouter
 
-from . import health, auth
+from . import health, auth, knowledge
 
 api_router = APIRouter()
 api_router.include_router(health.router)
 api_router.include_router(auth.router, prefix="/api/v1/auth")
+api_router.include_router(knowledge.router, prefix="/api/v1")

--- a/backend/gaigentic_backend/routes/knowledge.py
+++ b/backend/gaigentic_backend/routes/knowledge.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, UploadFile, File, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from ..database import async_session
+from ..models.agent import Agent
+from ..models.knowledge_chunk import KnowledgeChunk
+from ..dependencies.auth import get_current_tenant_id, require_role
+from ..services.file_loader import load_file
+from ..services.chunking import split_text
+from ..services.embedding import get_embedding
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.post("/agents/{agent_id}/knowledge/upload")
+async def upload_knowledge(
+    agent_id: UUID,
+    file: UploadFile = File(...),
+    session: AsyncSession = Depends(async_session),
+    tenant_id: UUID = Depends(get_current_tenant_id),
+    _user=Depends(require_role({"admin", "user"})),
+) -> dict:
+    """Upload a knowledge file and store vector chunks."""
+
+    start = time.time()
+    agent = await session.get(Agent, agent_id)
+    if agent is None or agent.tenant_id != tenant_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+
+    text = await load_file(file)
+    parts = split_text(text, max_tokens=500)
+
+    records: List[KnowledgeChunk] = []
+    for idx, chunk in enumerate(parts):
+        embedding = await get_embedding(chunk)
+        records.append(
+            KnowledgeChunk(
+                tenant_id=tenant_id,
+                agent_id=agent_id,
+                source_file=file.filename or "",
+                chunk_index=idx,
+                text=chunk,
+                embedding=embedding,
+            )
+        )
+
+    session.add_all(records)
+    try:
+        await session.commit()
+    except Exception as exc:  # pragma: no cover - runtime path
+        logger.exception("Failed to store knowledge chunks: %s", exc)
+        await session.rollback()
+        raise HTTPException(status_code=500, detail="Could not store knowledge") from exc
+
+    elapsed = int((time.time() - start) * 1000)
+    logger.info(
+        "Ingested %s chunks from %s for agent %s in %sms", len(records), file.filename, agent_id, elapsed
+    )
+    return {"chunks": len(records)}
+
+
+@router.get("/agents/{agent_id}/knowledge/search")
+async def search_knowledge(
+    agent_id: UUID,
+    q: str,
+    session: AsyncSession = Depends(async_session),
+    tenant_id: UUID = Depends(get_current_tenant_id),
+    _user=Depends(require_role({"admin", "user", "readonly"})),
+) -> List[dict]:
+    """Return top 5 knowledge chunks most similar to the query."""
+
+    agent = await session.get(Agent, agent_id)
+    if agent is None or agent.tenant_id != tenant_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+
+    query_vec = await get_embedding(q)
+    stmt = (
+        select(KnowledgeChunk.source_file, KnowledgeChunk.chunk_index, KnowledgeChunk.text)
+        .where(
+            KnowledgeChunk.agent_id == agent_id,
+            KnowledgeChunk.tenant_id == tenant_id,
+        )
+        .order_by(KnowledgeChunk.embedding.cosine_distance(query_vec))
+        .limit(5)
+    )
+    result = await session.execute(stmt)
+    return [dict(r) for r in result.all()]

--- a/backend/gaigentic_backend/services/chunking.py
+++ b/backend/gaigentic_backend/services/chunking.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import tiktoken
+
+
+def split_text(text: str, max_tokens: int = 500) -> list[str]:
+    """Split text into token-aware chunks."""
+
+    enc = tiktoken.get_encoding("cl100k_base")
+    normalized = " ".join(text.split())
+    tokens = enc.encode(normalized)
+    chunks = []
+    for i in range(0, len(tokens), max_tokens):
+        chunk_tokens = tokens[i : i + max_tokens]
+        chunks.append(enc.decode(chunk_tokens))
+    return chunks

--- a/backend/gaigentic_backend/services/embedding.py
+++ b/backend/gaigentic_backend/services/embedding.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import logging
+from typing import List
+
+import openai
+
+from ..config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def get_embedding(text: str) -> List[float]:
+    """Return embedding vector for the given text."""
+
+    if not settings.openai_api_key:
+        raise RuntimeError("OpenAI API key not configured")
+
+    client = openai.AsyncOpenAI(api_key=settings.openai_api_key)
+    try:
+        resp = await client.embeddings.create(
+            model="text-embedding-3-small",
+            input=text,
+        )
+    except Exception as exc:  # pragma: no cover - runtime errors
+        logger.exception("Embedding request failed: %s", exc)
+        raise
+    return resp.data[0].embedding

--- a/backend/gaigentic_backend/services/file_loader.py
+++ b/backend/gaigentic_backend/services/file_loader.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import os
+import logging
+from io import BytesIO
+
+from fastapi import UploadFile, HTTPException, status
+import fitz  # PyMuPDF
+from docx import Document
+
+logger = logging.getLogger(__name__)
+
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+
+
+async def load_file(file: UploadFile) -> str:
+    """Extract plain text from an uploaded file."""
+
+    file.file.seek(0, os.SEEK_END)
+    size = file.file.tell()
+    file.file.seek(0)
+    if size > MAX_FILE_SIZE:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="File too large")
+
+    filename = (file.filename or "").lower()
+    try:
+        if filename.endswith(".pdf"):
+            data = await file.read()
+            doc = fitz.open(stream=data, filetype="pdf")
+            text = "".join(page.get_text() for page in doc)
+            doc.close()
+        elif filename.endswith(".docx"):
+            data = await file.read()
+            doc = Document(BytesIO(data))
+            text = "\n".join(p.text for p in doc.paragraphs)
+        elif filename.endswith(".txt"):
+            text = (await file.read()).decode("utf-8", "ignore")
+        else:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Unsupported file format")
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - runtime parse errors
+        logger.exception("Failed to load file: %s", exc)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid file") from exc
+
+    return text

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,7 @@ httpx
 openai
 passlib[bcrypt]
 PyJWT
+tiktoken
+PyMuPDF
+python-docx
+pgvector

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import Chat from './pages/Chat'
 import Builder from './pages/Builder'
 import Monitor from './pages/Monitor'
 import Templates from './pages/Templates'
+import Knowledge from './pages/Knowledge'
 import Login from './pages/Login'
 import Register from './pages/Register'
 import { getToken, clearToken } from './utils/auth'
@@ -22,6 +23,7 @@ export default function App() {
         <Link to="/Builder" className="text-blue-600">Builder</Link>
         <Link to="/Templates" className="text-blue-600">Templates</Link>
         <Link to="/Monitor" className="text-blue-600">Monitor</Link>
+        <Link to="/Knowledge" className="text-blue-600">Knowledge</Link>
         {token ? (
           <button onClick={logout} className="text-blue-600">Logout</button>
         ) : (
@@ -33,6 +35,7 @@ export default function App() {
         <Route path="/Builder" element={<Builder />} />
         <Route path="/Templates" element={<Templates />} />
         <Route path="/Monitor" element={<Monitor />} />
+        <Route path="/Knowledge" element={<Knowledge />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
       </Routes>

--- a/frontend/src/pages/Knowledge.tsx
+++ b/frontend/src/pages/Knowledge.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { getToken } from '../utils/auth'
+
+interface Result {
+  source_file: string
+  chunk_index: number
+  text: string
+}
+
+interface UploadEntry {
+  name: string
+  time: string
+}
+
+export default function Knowledge() {
+  const location = useLocation()
+  const params = new URLSearchParams(location.search)
+  const agentId = params.get('agent_id') || ''
+
+  const [file, setFile] = useState<File | null>(null)
+  const [uploads, setUploads] = useState<UploadEntry[]>([])
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<Result[]>([])
+
+  const upload = async () => {
+    if (!file || !agentId) return
+    const form = new FormData()
+    form.append('file', file)
+    await fetch(`/api/v1/agents/${agentId}/knowledge/upload`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${getToken()}` },
+      body: form,
+    })
+      .then((r) => r.json())
+      .then(() => {
+        setUploads((u) => [...u, { name: file.name, time: new Date().toISOString() }])
+        setFile(null)
+      })
+      .catch(() => {})
+  }
+
+  const search = async () => {
+    if (!query.trim() || !agentId) return
+    const res = await fetch(`/api/v1/agents/${agentId}/knowledge/search?q=` + encodeURIComponent(query), {
+      headers: { Authorization: `Bearer ${getToken()}` },
+    })
+      .then((r) => r.json())
+      .catch(() => null)
+    if (res) setResults(res as Result[])
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div>
+        <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+        <button className="ml-2 px-2 py-1 bg-blue-500 text-white rounded" onClick={upload} disabled={!file}>
+          Upload
+        </button>
+      </div>
+      {uploads.length > 0 && (
+        <div>
+          <h3 className="font-bold">Uploads</h3>
+          <ul className="list-disc ml-6">
+            {uploads.map((u, i) => (
+              <li key={i}>{u.name} - {new Date(u.time).toLocaleString()}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div>
+        <input className="border p-1" value={query} onChange={(e) => setQuery(e.target.value)} />
+        <button className="ml-2 px-2 py-1 bg-green-600 text-white rounded" onClick={search}>
+          Search
+        </button>
+      </div>
+      <div>
+        {results.map((r, i) => (
+          <div key={i} className="border-b py-1 text-sm">
+            <div className="font-bold">{r.source_file} [{r.chunk_index}]</div>
+            <div>{r.text}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add knowledge chunk model and migration
- support uploading/searching knowledge chunks
- create file loader, chunking, and embedding helpers
- expose knowledge router in API
- update requirements for PDF/DOCX ingestion and vector search
- add React page for uploading/searching agent knowledge

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526b5ba81c832cb267933b3adb3504