### PR TITLE
Fix docker compose for Superagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@ Superagent service and stores configuration in PostgreSQL.
 
 ## Local development
 
+Clone the Superagent service and start the stack:
+
 ```bash
+git clone https://github.com/superagent-ai/superagent.git superagent
 cp .env.development .env
+docker compose build superagent
 docker compose up -d
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: "3.8"
 services:
   superagent:
-    image: homanp/superagent:latest
+    build:
+      context: ./superagent/libs/superagent
+      dockerfile: Dockerfile
     ports:
       - "8080:8080"
   gaigentic-backend:


### PR DESCRIPTION
## Summary
- build Superagent from source instead of pulling missing `homanp/superagent` image
- document cloning the Superagent repo for local development

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685282a8ce60832c963a5b2688a11daa