### PR TITLE
Add setup script for Superagent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 .env
 **/node_modules/
 frontend/dist/
+
+superagent/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ docker compose build superagent
 docker compose up -d
 ```
 
+You can also run the convenience script which performs the above steps
+automatically:
+
+```bash
+./scripts/setup_superagent.sh
+```
+
 The API will be available at `http://localhost:8001` and the health check at
 `/healthz`.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+python_files = test_*.py
+testpaths = tests

--- a/scripts/setup_superagent.sh
+++ b/scripts/setup_superagent.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="https://github.com/superagent-ai/superagent.git"
+TARGET_DIR="superagent"
+
+if [ ! -d "$TARGET_DIR" ]; then
+  echo "Cloning Superagent repository..."
+  git clone "$REPO_URL" "$TARGET_DIR"
+fi
+
+if [ ! -f .env ]; then
+  echo "Creating .env from .env.development"
+  cp .env.development .env
+fi
+
+docker compose build superagent
+docker compose up -d


### PR DESCRIPTION
## Summary
- add setup_superagent.sh convenience script
- mention the script in README
- ignore cloned superagent repo
- configure pytest to only collect real tests

## Testing
- `pip install -r backend/requirements.txt`
- `pip install aiosqlite deepdiff`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68529a39f180832ca6436d457b06ffc6