### PR TITLE
Fix docker compose context for Superagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Superagent service and stores configuration in PostgreSQL.
 ## Local development
 
 Start the stack. Docker Compose now pulls the Superagent service directly from
-GitHub, so no manual clone is required:
+GitHub using the `main:libs/superagent` subdirectory, so no manual clone is
+required:
 
 ```bash
 cp .env.development .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,9 @@ services:
     build:
       # Fetch the Superagent service directly from GitHub so users don't need
       # to clone the repository locally.
-      context: https://github.com/superagent-ai/superagent.git#libs/superagent
+      # Pin to the main branch and specify the subdirectory containing the
+      # Dockerfile using the <ref>:<path> syntax.
+      context: https://github.com/superagent-ai/superagent.git#main:libs/superagent
       dockerfile: Dockerfile
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Summary
- fix GitHub context for superagent service
- document subdirectory used in README

## Testing
- `pip install -q -r backend/requirements.txt`
- `pip install -q aiosqlite`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852aaa31f70832ca512e1aacf8f033e