### PR TITLE
Add root setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can also run the convenience script which performs the above steps
 automatically:
 
 ```bash
-./scripts/setup_superagent.sh
+./setup_superagent.sh
 ```
 
 The API will be available at `http://localhost:8001` and the health check at

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+CMD ["npm", "run", "dev"]

--- a/setup_superagent.sh
+++ b/setup_superagent.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -f .env ]; then
+  echo "Creating .env from .env.development"
+  cp .env.development .env
+fi
+
+docker compose build superagent
+docker compose up -d


### PR DESCRIPTION
## Summary
- provide convenience script `setup_superagent.sh` at repo root
- document using the new script in README
- add Dockerfile for frontend service to fix build

## Testing
- `bash -n setup_superagent.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852c1be7230832cabc326f94776e535