### PR TITLE
Fix Superagent setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Superagent service and stores configuration in PostgreSQL.
 
 ## Local development
 
-Start the stack by cloning the Superagent repository locally. The included
-`setup_superagent.sh` script will download the source if it is missing and then
-build the Docker images:
+Start the stack by cloning the Superagent repository locally. The
+`setup_superagent.sh` script will automatically clone the repository if it is
+missing and then build the Docker images:
 
 ```bash
 git clone https://github.com/superagent-ai/superagent.git external/superagent

--- a/setup_superagent.sh
+++ b/setup_superagent.sh
@@ -6,7 +6,14 @@ if [ ! -f .env ]; then
   cp .env.development .env
 fi
 
-git submodule update --init --recursive
+if [ ! -d external/superagent ]; then
+  echo "Cloning Superagent repository"
+  mkdir -p external
+  git clone https://github.com/superagent-ai/superagent.git external/superagent
+else
+  echo "Updating Superagent submodule"
+  git submodule update --init --recursive
+fi
 
 docker compose build superagent
 docker compose up -d


### PR DESCRIPTION
## Summary
- fix the helper script so it clones the Superagent repo when missing
- document automatic cloning in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852dd0f9324832c82b7a15d7057f19e