### PR TITLE
Fix llm_providers env parsing

### DIFF
--- a/backend/gaigentic_backend/config.py
+++ b/backend/gaigentic_backend/config.py
@@ -21,7 +21,9 @@ class Settings(BaseSettings):
     database_url: str = Field(..., alias="DATABASE_URL")
     superagent_url: str = Field(..., alias="SUPERAGENT_URL")
     app_env: str = Field(APP_ENV, alias="APP_ENV")
-    llm_providers_enabled: list[str] = Field(["openai"], alias="LLM_PROVIDERS_ENABLED")
+    llm_providers_enabled: list[str] | str = Field(
+        ["openai"], alias="LLM_PROVIDERS_ENABLED"
+    )
     openai_api_key: str | None = Field(None, alias="OPENAI_API_KEY")
     claude_api_key: str | None = Field(None, alias="CLAUDE_API_KEY")
     mistral_api_key: str | None = Field(None, alias="MISTRAL_API_KEY")
@@ -36,7 +38,7 @@ class Settings(BaseSettings):
     memory_chat_k_default: int = Field(10, alias="MEMORY_CHAT_K_DEFAULT")
     memory_semantic_k_default: int = Field(5, alias="MEMORY_SEMANTIC_K_DEFAULT")
 
-    @field_validator("llm_providers_enabled", mode="before")
+    @field_validator("llm_providers_enabled", mode="after")
     @classmethod
     def _split_providers(cls, v: str | list[str]) -> list[str]:
         if isinstance(v, str):

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,7 @@ services:
     image: postgres:15
     environment:
       POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: superagent
     volumes:
       - /data/postgres:/var/lib/postgresql/data
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     image: postgres:15
     environment:
       POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: superagent
     volumes:
       - postgres_data:/var/lib/postgresql/data
   redis:


### PR DESCRIPTION
## Summary
- handle string/JSON for `LLM_PROVIDERS_ENABLED`
- create `superagent` DB automatically in docker-compose files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852e47c0b8c832cae0fc47035728284